### PR TITLE
Check ConnectionStatus#error_message before rule failures

### DIFF
--- a/app/views/connect/index.html.erb
+++ b/app/views/connect/index.html.erb
@@ -81,7 +81,9 @@
 
     <% if @connect_status.step_error?(:add) %>
       <div class="alert alert-danger">
-        <% if @connect_status.github_user %>
+        <% if @connect_status.error_message %>
+          <p><%= @connect_status.error_message %></p>
+        <% elsif @connect_status.github_user %>
           <p>Sorry, your GitHub account cannot be added due to the following <%= "error".pluralize(@connect_status.github_user.failing_rules.count) %>:</p>
           <ul>
             <% @connect_status.github_user.failing_rules.each do |rule| %>
@@ -89,8 +91,6 @@
             <% end %>
           </ul>
           <p>Please correct these errors and <%= link_to "try again", {action: 'start'} %>.</p>
-        <% elsif @connect_status.error_message %>
-          <p><%= @connect_status.error_message %></p>
         <% else %>
           <p>An unknown error occurred.  Please <%= link_to "try again", {action: 'start'} %> again.</p>
         <% end %>


### PR DESCRIPTION
Previously if an error occurred and created an `error_message` then it would only propagate if `github_user` was falsy. ![screen shot 2014-12-19 at 01 08 30](https://cloud.githubusercontent.com/assets/1694055/5501195/a265e30e-871b-11e4-8741-6174cfbf77a0.png)
