### PR TITLE
Allow usernames with dots

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -36,7 +36,7 @@ Rails.application.routes.draw do
 
   devise_for :users
 
-  resources :users, only: [:index, :show, :edit, :update]
+  resources :users, only: [:index, :show, :edit, :update], constraints: { id: /[^\/]+/ }
   resources :github_users, only: [:index, :show]
 
   root 'dashboard#index'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -36,7 +36,7 @@ Rails.application.routes.draw do
 
   devise_for :users
 
-  resources :users, only: [:index, :show, :edit, :update], constraints: { id: /[^\/]+/ }
+  resources :users, only: [:index, :show, :edit, :update], constraints: { id: /[^\/]+?/ }, :format => /html/
   resources :github_users, only: [:index, :show]
 
   root 'dashboard#index'


### PR DESCRIPTION
By default, rails uses dots to delimit the format of the urls. Since
this app uses usernames in urls and a lot of companies have dots in
their username schemes, it is necessary to allow this.