### PR TITLE
Use HTTPS instead of GIT to access github

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,7 +13,7 @@ gem 'devise', '>= 3.4.0'
 # see: https://github.com/cschiewek/devise_ldap_authenticatable/pull/172
 #      https://github.com/cschiewek/devise_ldap_authenticatable/pull/171
 #      https://github.com/cschiewek/devise_ldap_authenticatable/pull/170
-gem 'devise_ldap_authenticatable', git: 'git://github.com/blt04/devise_ldap_authenticatable.git', branch: 'patches'
+gem 'devise_ldap_authenticatable', git: 'https://github.com/blt04/devise_ldap_authenticatable.git', branch: 'patches'
 gem 'friendly_id'
 gem 'font-awesome-rails'
 gem 'jquery-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,5 +1,5 @@
 GIT
-  remote: git://github.com/blt04/devise_ldap_authenticatable.git
+  remote: https://github.com/blt04/devise_ldap_authenticatable.git
   revision: 76db2d04b5d11e5f01b8bb83da9eca83f0ef6fad
   branch: patches
   specs:

--- a/cookbook/attributes/default.rb
+++ b/cookbook/attributes/default.rb
@@ -2,7 +2,7 @@ default['github_connector']['user'] = 'github'
 default['github_connector']['group'] = node['github_connector']['user']
 default['github_connector']['install_dir'] = '/var/www/github-connector'
 
-default['github_connector']['repo']['url'] = 'git://github.com/rapid7/github-connector.git'
+default['github_connector']['repo']['url'] = 'https://github.com/rapid7/github-connector.git'
 default['github_connector']['repo']['revision'] = 'v0.1.2'
 
 # The secrets databag can contain the following keys:


### PR DESCRIPTION
Most corporate firewalls block git:// access and using https:// is
equivalent.