### PR TITLE
Add a simple API via HTTP basic auth

### DIFF
--- a/app/controllers/github_users_controller.rb
+++ b/app/controllers/github_users_controller.rb
@@ -5,9 +5,17 @@ class GithubUsersController < ApplicationController
   def index
     # TODO: Pagination
     @github_users = GithubUser.includes(:user).order(:login)
+    respond_to do |format|
+      format.html
+      format.json { render json: @github_users }
+    end
   end
 
   def show
+    respond_to do |format|
+      format.html
+      format.json { render json: @github_user }
+    end
   end
 
   private

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -6,9 +6,17 @@ class UsersController < ApplicationController
   def index
     # TODO: Pagination
     @users = User.includes(:github_users).order(:name)
+    respond_to do |format|
+      format.html
+      format.json { render json: @users }
+    end
   end
 
   def show
+    respond_to do |format|
+      format.html
+      format.json { render json: @user }
+    end
   end
 
   def edit

--- a/app/models/github_user.rb
+++ b/app/models/github_user.rb
@@ -170,6 +170,16 @@ class GithubUser < ActiveRecord::Base
     end
   end
 
+  def as_json(options={})
+    options[:except] ||= []
+    options[:except] += [:encrypted_token, :id, :user_id]
+    json = super(options)
+    unless options[:except].include?(:user)
+      json['user'] = user.as_json(except: [:github_users])
+    end
+    json
+  end
+
   # Should the Github user be excluded from processing by global settings?
   #
   # @return [Boolean]

--- a/app/models/github_user.rb
+++ b/app/models/github_user.rb
@@ -177,6 +177,9 @@ class GithubUser < ActiveRecord::Base
     unless options[:except].include?(:user)
       json['user'] = user.as_json(except: [:github_users])
     end
+    unless options[:except].include?(:teams)
+      json['teams'] = teams.map { |ghteam| ghteam.full_slug }
+    end
     json
   end
 

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -71,6 +71,7 @@ Devise.setup do |config|
   # enable it only for database authentication. The supported strategies are:
   # :database      = Support basic authentication with authentication key + password
   # config.http_authenticatable = false
+  config.http_authenticatable = true
 
   # If http headers should be returned for AJAX requests. True by default.
   # config.http_authenticatable_on_xhr = true

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -36,7 +36,7 @@ Rails.application.routes.draw do
 
   devise_for :users
 
-  resources :users, only: [:index, :show, :edit, :update], constraints: { id: /[^\/]+?/ }, format: /html/
+  resources :users, only: [:index, :show, :edit, :update], constraints: { id: /[^\/]+?/ }
   resources :github_users, only: [:index, :show]
 
   root 'dashboard#index'

--- a/spec/models/github_user_spec.rb
+++ b/spec/models/github_user_spec.rb
@@ -321,6 +321,13 @@ describe GithubUser do
     expect(user.github_admin).to be_a(GithubAdmin)
   end
 
+  it 'excludes internal data from json' do
+    json = user.as_json
+    expect(json).to_not include('encrypted_token')
+    expect(json).to_not include('id')
+    expect(json).to_not include('user_id')
+  end
+
   describe '#do_enable' do
     let(:transition) { double.as_null_object }
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -9,6 +9,11 @@ describe User do
   let(:email) { 'foouser@example.com' }
   let(:user_account_control) { 512 }
 
+  it 'excludes internal data from json' do
+    json = user.as_json
+    expect(json).to_not include('id')
+  end
+
   context 'with ldap' do
     let(:ldap) { double }
     let(:ldap_connection) { double(ldap: ldap) }
@@ -122,6 +127,12 @@ describe User do
       expect(emails).to be_an(Array)
       expect(emails).to_not be_empty
       expect(emails).to include(/githubemail\d+@example.com/)
+    end
+
+    it 'includes Github usernames in json' do
+      json = user.as_json
+      expect(json).to include('github_users')
+      expect(json['github_users']).to include(github_users.first.login)
     end
   end
 


### PR DESCRIPTION
The following JSON endpoints are supported:
* /users.json
* /users/<username>.json
* /github_users.json
* /github_users/<github_username>.json