### PR TITLE
Use databags for githubapp yaml in ext

### DIFF
--- a/cookbook/recipes/server.rb
+++ b/cookbook/recipes/server.rb
@@ -81,6 +81,16 @@ node['github_connector']['engines'].each do |engine, attrs|
   end
 end
 
+# Create the yaml config for the github connector r7 extensions GithubApp info
+template "/vendor/engines/github_connector_r7_extensions/config/github_apps.yml" do
+  source 'github_apps.yml.erb'
+  mode 0644
+  owner node['github_connector']['user']
+  group node['github_connector']['group']
+  action :create
+  )
+end
+
 
 # Create an alias that remains consistent across version/gemset changes
 execute 'github-connector-alias' do

--- a/cookbook/templates/default/github_apps.yml.erb
+++ b/cookbook/templates/default/github_apps.yml.erb
@@ -1,0 +1,81 @@
+GithubApp:
+  arci:
+    name: Arci
+    app_id: 113121
+    access_token: <% @data_bag_item('github-apps', 'github-token')['token'] %>
+    private_key: <% @data_bag_item('github-apps', 'arci-pem')['pem'] %>
+  infosecci:
+    name: Infosecci
+    app_id: 113402
+    access_token: <% @data_bag_item('github-apps', 'github-token')['token'] %>
+    private_key: <% @data_bag_item('github-apps', 'infosecci-pem')['pem'] %>
+  insightvmci:
+    name: Insightvmci
+    app_id: 113403
+    access_token: <% @data_bag_item('github-apps', 'github-token')['token'] %>
+    private_key: <% @data_bag_item('github-apps', 'insightvm-pem')['pem'] %>
+  itci:
+    name: Itci
+    app_id: 113401
+    access_token: <% @data_bag_item('github-apps', 'github-token')['token'] %>
+    private_key: <% @data_bag_item('github-apps', 'itci-pem')['pem'] %>
+  kittyci:
+    name: Kittyci
+    app_id: 113404
+    access_token: <% @data_bag_item('github-apps', 'github-token')['token'] %>
+    private_key: <% @data_bag_item('github-apps', 'kittyci-pem')['pem'] %>
+  komandci:
+    name: Komandci
+    app_id: 113406
+    access_token: <% @data_bag_item('github-apps', 'github-token')['token'] %>
+    private_key: <% @data_bag_item('github-apps', 'komandci-pem')['pem'] %>
+  labsci:
+    name: Labsci
+    app_id: 113407
+    access_token: <% @data_bag_item('github-apps', 'github-token')['token'] %>
+    private_key: <% @data_bag_item('github-apps', 'labsci-pem')['pem'] %>
+  leci:
+    name: Leci
+    app_id: 113408
+    access_token: <% @data_bag_item('github-apps', 'github-token')['token'] %>
+    private_key: <% @data_bag_item('github-apps', 'leci-pem')['pem'] %>
+  msjenkins:
+    name: Msjenkins
+    app_id: 113409
+    access_token: <% @data_bag_item('github-apps', 'github-token')['token'] %>
+    private_key: <% @data_bag_item('github-apps', 'msjenkins-pem')['pem'] %>
+  myci:
+    name: Myci
+    app_id: 113410
+    access_token: <% @data_bag_item('github-apps', 'github-token')['token'] %>
+    private_key: <% @data_bag_item('github-apps', 'myci-pem')['pem'] %>
+  pdci:
+    name: Pdci
+    app_id: 112906
+    access_token: <% @data_bag_item('github-apps', 'github-token')['token'] %>
+    private_key: <% @data_bag_item('github-apps', 'pdci-pem')['pem'] %>
+  prodci:
+    name: Prodci
+    app_id: 113411
+    access_token: <% @data_bag_item('github-apps', 'github-token')['token'] %>
+    private_key: <% @data_bag_item('github-apps', 'prodci-pem')['pem'] %>
+  razorci:
+    name: Razorci
+    app_id: 113412
+    access_token: <% @data_bag_item('github-apps', 'github-token')['token'] %>
+    private_key: <% @data_bag_item('github-apps', 'razorci-pem')['pem'] %>
+  servicesci:
+    name: Servicesci
+    app_id: 113413
+    access_token: <% @data_bag_item('github-apps', 'github-token')['token'] %>
+    private_key: <% @data_bag_item('github-apps', 'servicesci-pem')['pem'] %>
+  spiderci:
+    name: Spiderci
+    app_id: 113414
+    access_token: <% @data_bag_item('github-apps', 'github-token')['token'] %>
+    private_key: <% @data_bag_item('github-apps', 'spiderci-pem')['pem'] %>
+  testci:
+    name: Testci 
+    app_id: 113600
+    access_token: <% @data_bag_item('github-apps', 'github-token')['token'] %>
+    private_key: <% @data_bag_item('github-apps', 'testci-pem')['pem'] %>

--- a/cookbook/templates/default/github_apps.yml.erb
+++ b/cookbook/templates/default/github_apps.yml.erb
@@ -64,6 +64,11 @@ GithubApp:
     app_id: 113412
     access_token: <% @data_bag_item('github-apps', 'github-token')['token'] %>
     private_key: <% @data_bag_item('github-apps', 'razorci-pem')['pem'] %>
+  commandci:
+    name: Commandci
+    app_id: 113412
+    access_token: <% @data_bag_item('github-apps', 'github-token')['token'] %>
+    private_key: <% @data_bag_item('github-apps', 'razorci-pem')['pem'] %>
   servicesci:
     name: Servicesci
     app_id: 113413


### PR DESCRIPTION
the pem files and a temporary pac for github has been added to a new knife data bag called github-apps. the token needs to be updated to use a token from a service account

my one concern is that i know github-connector is open source so i'm not sure if we want to put information / a template file that contains information kind of hinting at how we're using github apps in our open source repo? 